### PR TITLE
Feature: Sections

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,12 +6,28 @@ Support for Sections within a single task file
 :* 1 section => equivalent to no section
 :* display sections in list
 :* display section of task in current/cycle
-* ability to focus section
-  * when focus section, blur other focused sections
-* current / cycle: pick only from focused task
+:* ability to focus section
+:  * when focus section, blur other focused sections
+:* current / cycle: pick only from focused task
 :* add, append: default top 1st section, bottom last section
 * add task --section Section => Add Task to section
   * Add to section with better match
   * Or Index sections by letter; add a "Something"
   * added tasks are always added 2 lines below the last text line of the section, except if there's already a task in the section, in which case the position of this task will be the place of insertion
-* tax section add "Section" (really?)
+* when add without --section, add to focused section if any
+* move task to section
+:* when focused, display only focused section in list (+hint "Other tasks in hidden sections...")
+
+# Scriptability
+
+* add export command for json export of model
+  * Or even better, add --json to every command to make their output JSON
+* add optional --file, similar to TASK_FILE env variable
+
+# Web UI
+
+* Maybe (prolly not) add web UI ?
+
+# Log file
+
+* Integrate feature? Or let it rely on outside scripting?

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,14 +2,14 @@
 
 Support for Sections within a single task file
 
-* a section is a markdown header
-* 1 section => equivalent to no section
-* display sections in list
-* display section of task in current/cycle
+:* a section is a markdown header
+:* 1 section => equivalent to no section
+:* display sections in list
+:* display section of task in current/cycle
 * ability to focus section
 * add, append: default top 1st section, bottom last section
 * tax section add "Section" (really?)
 * add task --section Section => Add Task to section
   * Add to section with better match
   * Or Index sections by letter; add a "Something"
-* added tasks ar always added 2 lines below the last text line of the section, except if there's already a task in the section, in which case the position of this task will be the place of insertion
+* added tasks are always added 2 lines below the last text line of the section, except if there's already a task in the section, in which case the position of this task will be the place of insertion

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,9 +7,11 @@ Support for Sections within a single task file
 :* display sections in list
 :* display section of task in current/cycle
 * ability to focus section
-* add, append: default top 1st section, bottom last section
-* tax section add "Section" (really?)
+  * when focus section, blur other focused sections
+* current / cycle: pick only from focused task
+:* add, append: default top 1st section, bottom last section
 * add task --section Section => Add Task to section
   * Add to section with better match
   * Or Index sections by letter; add a "Something"
-* added tasks are always added 2 lines below the last text line of the section, except if there's already a task in the section, in which case the position of this task will be the place of insertion
+  * added tasks are always added 2 lines below the last text line of the section, except if there's already a task in the section, in which case the position of this task will be the place of insertion
+* tax section add "Section" (really?)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,13 +10,16 @@ Support for Sections within a single task file
 :  * when focus section, blur other focused sections
 :* current / cycle: pick only from focused task
 :* add, append: default top 1st section, bottom last section
-* add task --section Section => Add Task to section
+:* add task --section Section => Add Task to section
   * Add to section with better match
   * Or Index sections by letter; add a "Something"
   * added tasks are always added 2 lines below the last text line of the section, except if there's already a task in the section, in which case the position of this task will be the place of insertion
-* when add without --section, add to focused section if any
-* move task to section
-:* when focused, display only focused section in list (+hint "Other tasks in hidden sections...")
+:* when add without --section, add to focused section if any
+* when focused, display only focused section in list (+hint "Other tasks in hidden sections...")
+
+# Tax --all (also tax list --all)
+
+: Lists all the tasks, regardless of section focus
 
 # Scriptability
 
@@ -31,3 +34,4 @@ Support for Sections within a single task file
 # Log file
 
 * Integrate feature? Or let it rely on outside scripting?
+

--- a/src/cmd_add.rs
+++ b/src/cmd_add.rs
@@ -1,9 +1,9 @@
 use crate::cmd_list;
-use crate::model::Task;
+use crate::model::{Section, Task};
 use crate::services::{ContentGetter, ContentSetter, StringOutputer, TaskFormatter, UserCmdRunner};
 use crate::tasks::{
-    get_all_tasks, task_to_markdown, text_add_line_in_str, text_get_comment, text_is_focused,
-    text_remove_focus,
+    filter_tasks_in_section, get_all_tasks, search_section, task_to_markdown, text_add_line_in_str,
+    text_get_comment, text_is_focused, text_remove_focus, text_replace_line_in_str,
 };
 
 pub enum AddPosition {
@@ -15,16 +15,69 @@ pub fn cmd(
     outputer: &mut dyn StringOutputer,
     content_getter: &dyn ContentGetter,
     content_setter: &mut dyn ContentSetter,
-    user_cmd_runner: &dyn UserCmdRunner,
+    _user_cmd_runner: &dyn UserCmdRunner,
     task_formatter: &TaskFormatter,
     task_parts: Vec<String>,
+    section_name: Option<String>,
     pos: AddPosition,
 ) -> Result<(), String> {
     let task_name = task_parts.join(" ");
 
-    let (tasks, _, _) = get_all_tasks(content_getter)?;
+    let (tasks, _use_sections, sections, focused_section) = get_all_tasks(content_getter)?;
 
-    let (line_num, task_num, operation) = if tasks.len() == 0 {
+    let (name_without_comment, comment) = text_get_comment(task_name.as_str());
+    let is_task_focused = text_is_focused(name_without_comment.as_str());
+    let plain_name = if is_task_focused {
+        text_remove_focus(name_without_comment.as_str())
+    } else {
+        name_without_comment
+    };
+
+    let new_line = task_to_markdown(&Task {
+        name: task_name.clone(),
+        plain_name: plain_name.clone(),
+        comment: comment,
+        line: String::from(""),
+        line_num: 0,
+        is_checked: false,
+        is_focused: is_task_focused,
+        num: 0,
+        section: None,
+    });
+
+    match section_name {
+        None => (),
+        Some(name) => match search_section(&name, &sections) {
+            // Section has been specified
+            None => return Err(format!("Section not found: {}", name)), // but does not exist;
+            Some(section) => {
+                return add_to_section(
+                    tasks,
+                    &section,
+                    &new_line,
+                    content_getter,
+                    content_setter,
+                    pos,
+                );
+            }
+        },
+    };
+
+    match focused_section {
+        None => (),
+        Some(s) => {
+            return add_to_section(
+                tasks,
+                s.as_ref(),
+                &new_line,
+                content_getter,
+                content_setter,
+                pos,
+            );
+        }
+    };
+
+    let (line_num, _task_num, _operation) = if tasks.len() == 0 {
         (1, 1, "APPEND".to_string())
     } else {
         match pos {
@@ -37,47 +90,68 @@ pub fn cmd(
         }
     };
 
-    let (name_without_comment, comment) = text_get_comment(task_name.as_str());
-    let is_task_focused = text_is_focused(name_without_comment.as_str());
-    let plain_name = if is_task_focused {
-        text_remove_focus(name_without_comment.as_str())
-    } else {
-        name_without_comment
-    };
-
-    let mut new_task = Task {
-        name: task_name.clone(),
-        plain_name: plain_name.clone(),
-        comment: comment,
-        line: String::from(""),
-        line_num: line_num,
-        is_checked: false,
-        is_focused: is_task_focused,
-        num: task_num,
-        section: None,
-    };
-
-    new_task.line = task_to_markdown(&new_task);
-    let result = text_add_line_in_str(
-        &content_getter.get_contents()?,
-        line_num,
-        new_task.line.clone(),
-    )?;
+    let result = text_add_line_in_str(&content_getter.get_contents()?, line_num, &new_line);
     content_setter.set_contents(result)?;
 
-    match user_cmd_runner.build(
-        String::from("add"),
-        operation,
-        format!("Added \"{}\"", task_name),
-    ) {
-        Ok(Some(mut cmd)) => {
-            user_cmd_runner.run(user_cmd_runner.env_single_task(new_task, &mut cmd))?;
-        }
-        Ok(None) => (),
-        Err(e) => return Err(e),
-    };
+    // FIXME: enable user_cmd_runner
+    // match user_cmd_runner.build(
+    //     String::from("add"),
+    //     operation,
+    //     format!("Added \"{}\"", task_name),
+    // ) {
+    //     Ok(Some(mut cmd)) => {
+    //         user_cmd_runner.run(user_cmd_runner.env_single_task(new_task, &mut cmd))?;
+    //     }
+    //     Ok(None) => (),
+    //     Err(e) => return Err(e),
+    // };
 
     cmd_list::cmd(outputer, content_getter, task_formatter)
+}
+
+fn add_to_section(
+    tasks: Vec<Task>,
+    section: &Section,
+    new_line: &str,
+    content_getter: &dyn ContentGetter,
+    content_setter: &mut dyn ContentSetter,
+    pos: AddPosition,
+) -> Result<(), String> {
+    // Add task to section
+    let section_tasks = filter_tasks_in_section(&tasks, section);
+
+    if section_tasks.len() == 0 {
+        // Section is empty;
+
+        let new_lines = format!("\n{}", new_line);
+        let result = text_add_line_in_str(
+            &content_getter.get_contents()?,
+            section.line_num_end + 1,
+            &new_lines,
+        );
+
+        return content_setter.set_contents(result);
+    } else {
+        let (new_lines, line_num) = match pos {
+            AddPosition::Prepend => (
+                format!("{}\n{}", new_line, section_tasks[0].line),
+                section_tasks[0].line_num,
+            ),
+            AddPosition::Append => (
+                format!(
+                    "{}\n{}",
+                    section_tasks[section_tasks.len() - 1].line,
+                    new_line,
+                ),
+                section_tasks[section_tasks.len() - 1].line_num,
+            ),
+        };
+
+        let result =
+            text_replace_line_in_str(&content_getter.get_contents()?, line_num, &new_lines);
+
+        return content_setter.set_contents(result);
+    }
 }
 
 #[cfg(test)]
@@ -102,6 +176,7 @@ mod tests {
             &user_cmd_runner,
             &task_formatter,
             vec!["**Some focused task** // with comments; see https://example.com".to_string()],
+            None,
             AddPosition::Prepend,
         ) {
             Ok(()) => assert_eq!(
@@ -129,6 +204,7 @@ mod tests {
             &user_cmd_runner,
             &task_formatter,
             vec!["Some task".to_string()],
+            None,
             AddPosition::Prepend,
         ) {
             Ok(()) => assert_eq!(
@@ -154,6 +230,7 @@ mod tests {
             &user_cmd_runner,
             &task_formatter,
             vec!["Some task".to_string()],
+            None,
             AddPosition::Append,
         ) {
             Ok(()) => assert_eq!(
@@ -184,6 +261,7 @@ mod tests {
             &user_cmd_runner,
             &task_formatter,
             vec!["Some task".to_string()],
+            None,
             AddPosition::Prepend,
         ) {
             Ok(()) => assert_eq!(
@@ -216,6 +294,7 @@ mod tests {
             &user_cmd_runner,
             &task_formatter,
             vec!["Some task".to_string()],
+            None,
             AddPosition::Append,
         ) {
             Ok(()) => assert_eq!(

--- a/src/cmd_add.rs
+++ b/src/cmd_add.rs
@@ -97,12 +97,14 @@ mod tests {
             &mut content_setter,
             &user_cmd_runner,
             &task_formatter,
-            vec!["Some task".to_string()],
+            vec!["**Some focused task** // with comments; see https://example.com".to_string()],
             AddPosition::Prepend,
         ) {
             Ok(()) => assert_eq!(
                 content_setter.content,
-                Some(String::from("- [ ] Some task\n"))
+                Some(String::from(
+                    "- [ ] **Some focused task** // with comments; see https://example.com\n"
+                ))
             ),
             Err(e) => panic!(e),
         }
@@ -159,7 +161,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cmd_add_after_section() {
+    fn test_cmd_add_top_section() {
         let mut string_outputer = StringOutputerMock::new();
         let content_getter = ContentGetterMock::new(Ok(vec![
             "# Section".to_string(),
@@ -183,6 +185,37 @@ mod tests {
                 content_setter.content,
                 Some(String::from(
                     "# Section\n\n- [ ] Some task\n- [ ] Existing task\n"
+                ))
+            ),
+            Err(e) => panic!(e),
+        }
+    }
+
+    #[test]
+    fn test_cmd_add_bottom_section() {
+        let mut string_outputer = StringOutputerMock::new();
+        let content_getter = ContentGetterMock::new(Ok(vec![
+            "# Section".to_string(),
+            "".to_string(),
+            "- [ ] Existing task".to_string(),
+        ]));
+        let mut content_setter = ContentSetterMock::new(Ok(()));
+        let user_cmd_runner = UserCmdRunnerMock::new();
+        let task_formatter = TaskFormatter::new(false);
+
+        match cmd(
+            &mut string_outputer,
+            &content_getter,
+            &mut content_setter,
+            &user_cmd_runner,
+            &task_formatter,
+            vec!["Some task".to_string()],
+            AddPosition::Append,
+        ) {
+            Ok(()) => assert_eq!(
+                content_setter.content,
+                Some(String::from(
+                    "# Section\n\n- [ ] Existing task\n- [ ] Some task\n"
                 ))
             ),
             Err(e) => panic!(e),

--- a/src/cmd_cat.rs
+++ b/src/cmd_cat.rs
@@ -5,7 +5,7 @@ pub fn cmd(
     content_getter: &dyn ContentGetter,
 ) -> Result<(), String> {
     let content = content_getter.get_contents()?;
-    for line in &content {
+    for line in content.lines() {
         outputer.info(line.to_string());
     }
 

--- a/src/cmd_cat.rs
+++ b/src/cmd_cat.rs
@@ -6,7 +6,7 @@ pub fn cmd(
 ) -> Result<(), String> {
     let content = content_getter.get_contents()?;
     for line in content.lines() {
-        outputer.info(line.to_string());
+        outputer.info(line);
     }
 
     Ok(())

--- a/src/cmd_check.rs
+++ b/src/cmd_check.rs
@@ -4,13 +4,13 @@ use crate::tasks::{get_all_tasks, task_to_markdown, text_replace_line_in_content
 pub fn cmd(
     outputer: &mut dyn StringOutputer,
     content_getter: &dyn ContentGetter,
-    content_setter: &dyn ContentSetter,
+    content_setter: &mut dyn ContentSetter,
     user_cmd_runner: &dyn UserCmdRunner,
     task_formatter: &TaskFormatter,
     rank_one_based: usize,
     checked: bool,
 ) -> Result<(), String> {
-    let tasks = get_all_tasks(content_getter)?;
+    let (tasks, _) = get_all_tasks(content_getter)?;
     if rank_one_based > tasks.len() {
         return Err(format!("Non existent task {}", rank_one_based));
     }

--- a/src/cmd_check.rs
+++ b/src/cmd_check.rs
@@ -18,13 +18,13 @@ pub fn cmd(
     let task = &tasks[rank_one_based - 1];
 
     if checked && task.is_checked {
-        outputer.info(format!(
+        outputer.info(&format!(
             "Already checked: {}",
             task_formatter.display_numbered_task(&task, use_sections)
         ));
         return Ok(());
     } else if !checked && !task.is_checked {
-        outputer.info(format!(
+        outputer.info(&format!(
             "Already unckecked: {}",
             task_formatter.display_numbered_task(&task, use_sections)
         ));
@@ -36,7 +36,7 @@ pub fn cmd(
     updated_task.line = task_to_markdown(&updated_task);
 
     let action = if checked { "Checked" } else { "Unchecked" };
-    outputer.info(format!(
+    outputer.info(&format!(
         "{}: {}",
         action,
         task_formatter.display_numbered_task(&updated_task, use_sections)
@@ -51,16 +51,16 @@ pub fn cmd(
     let result = content_setter.set_contents(replaced_content);
 
     match user_cmd_runner.build(
-        String::from("check"),
-        String::from(if checked { "CHECK" } else { "UNCHECK" }),
-        format!(
+        "check",
+        if checked { "CHECK" } else { "UNCHECK" },
+        &format!(
             "Marked \"{}\" as {}",
             updated_task.name,
             if checked { "done" } else { "not done" }
         ),
     ) {
         Ok(Some(mut cmd)) => {
-            user_cmd_runner.run(user_cmd_runner.env_single_task(updated_task, &mut cmd))?;
+            user_cmd_runner.run(user_cmd_runner.env_single_task(&updated_task, &mut cmd))?;
         }
         Ok(None) => (),
         Err(e) => return Err(e),

--- a/src/cmd_check.rs
+++ b/src/cmd_check.rs
@@ -10,7 +10,7 @@ pub fn cmd(
     rank_one_based: usize,
     checked: bool,
 ) -> Result<(), String> {
-    let (tasks, _) = get_all_tasks(content_getter)?;
+    let (tasks, use_sections) = get_all_tasks(content_getter)?;
     if rank_one_based > tasks.len() {
         return Err(format!("Non existent task {}", rank_one_based));
     }
@@ -20,13 +20,13 @@ pub fn cmd(
     if checked && task.is_checked {
         outputer.info(format!(
             "Already checked: {}",
-            task_formatter.display_numbered_task(&task)
+            task_formatter.display_numbered_task(&task, use_sections)
         ));
         return Ok(());
     } else if !checked && !task.is_checked {
         outputer.info(format!(
             "Already unckecked: {}",
-            task_formatter.display_numbered_task(&task)
+            task_formatter.display_numbered_task(&task, use_sections)
         ));
         return Ok(());
     }
@@ -39,7 +39,7 @@ pub fn cmd(
     outputer.info(format!(
         "{}: {}",
         action,
-        task_formatter.display_numbered_task(&updated_task)
+        task_formatter.display_numbered_task(&updated_task, use_sections)
     ));
 
     let replaced_content = text_replace_line_in_contents(

--- a/src/cmd_check.rs
+++ b/src/cmd_check.rs
@@ -10,7 +10,7 @@ pub fn cmd(
     rank_one_based: usize,
     checked: bool,
 ) -> Result<(), String> {
-    let (tasks, use_sections, _) = get_all_tasks(content_getter)?;
+    let (tasks, use_sections, _, _) = get_all_tasks(content_getter)?;
     if rank_one_based > tasks.len() {
         return Err(format!("Non existent task {}", rank_one_based));
     }

--- a/src/cmd_check.rs
+++ b/src/cmd_check.rs
@@ -1,5 +1,5 @@
 use crate::services::{ContentGetter, ContentSetter, StringOutputer, TaskFormatter, UserCmdRunner};
-use crate::tasks::{get_all_tasks, task_to_markdown, text_replace_line_in_contents};
+use crate::tasks::{get_all_tasks, task_to_markdown, text_replace_line_in_str};
 
 pub fn cmd(
     outputer: &mut dyn StringOutputer,
@@ -10,7 +10,7 @@ pub fn cmd(
     rank_one_based: usize,
     checked: bool,
 ) -> Result<(), String> {
-    let (tasks, use_sections) = get_all_tasks(content_getter)?;
+    let (tasks, use_sections, _) = get_all_tasks(content_getter)?;
     if rank_one_based > tasks.len() {
         return Err(format!("Non existent task {}", rank_one_based));
     }
@@ -42,11 +42,11 @@ pub fn cmd(
         task_formatter.display_numbered_task(&updated_task, use_sections)
     ));
 
-    let replaced_content = text_replace_line_in_contents(
-        content_getter,
+    let replaced_content = text_replace_line_in_str(
+        &content_getter.get_contents()?,
         updated_task.line_num,
-        updated_task.line.clone(),
-    )?;
+        &updated_task.line,
+    );
 
     let result = content_setter.set_contents(replaced_content);
 

--- a/src/cmd_current.rs
+++ b/src/cmd_current.rs
@@ -18,7 +18,7 @@ pub fn cmd(
 mod tests {
 
     use super::*;
-    use crate::test_helpers::{get_std_test_contents, FileReaderMock, StringOutputerMock};
+    use crate::test_helpers::test::{get_std_test_contents, ContentGetterMock, StringOutputerMock};
 
     #[test]
     fn test_cmd_current() {
@@ -28,9 +28,7 @@ mod tests {
         // Empty contents
         {
             let outputer_mock = &mut StringOutputerMock::new();
-            let content_getter_mock = &FileReaderMock {
-                outcome: Ok(Vec::new()),
-            };
+            let content_getter_mock = &ContentGetterMock::new(Ok(Vec::new()));
 
             cmd(outputer_mock, content_getter_mock, &task_formatter, false).unwrap();
             assert_eq!(outputer_mock.get_info(), "");
@@ -40,9 +38,7 @@ mod tests {
         {
             let outputer_mock = &mut StringOutputerMock::new();
             let (test_contents, _) = get_std_test_contents();
-            let content_getter_mock = &FileReaderMock {
-                outcome: Ok(test_contents),
-            };
+            let content_getter_mock = &ContentGetterMock::new(Ok(test_contents));
 
             cmd(outputer_mock, content_getter_mock, &task_formatter, false).unwrap();
             assert_eq!(

--- a/src/cmd_current.rs
+++ b/src/cmd_current.rs
@@ -8,7 +8,9 @@ pub fn cmd(
     cycle: bool,
 ) -> Result<(), String> {
     match get_current_task(content_getter, cycle) {
-        Ok(Some(task)) => outputer.info(task_formatter.display_numbered_task(&task)),
+        Ok(Some((task, use_sections))) => {
+            outputer.info(task_formatter.display_numbered_task(&task, use_sections))
+        }
         _ => (),
     };
     Ok(())

--- a/src/cmd_current.rs
+++ b/src/cmd_current.rs
@@ -30,7 +30,7 @@ mod tests {
         // Empty contents
         {
             let outputer_mock = &mut StringOutputerMock::new();
-            let content_getter_mock = &ContentGetterMock::new(Ok(Vec::new()));
+            let content_getter_mock = &ContentGetterMock::new(Ok("".to_string()));
 
             cmd(outputer_mock, content_getter_mock, &task_formatter, false).unwrap();
             assert_eq!(outputer_mock.get_info(), "");

--- a/src/cmd_current.rs
+++ b/src/cmd_current.rs
@@ -9,7 +9,7 @@ pub fn cmd(
 ) -> Result<(), String> {
     match get_current_task(content_getter, cycle) {
         Ok(Some((task, use_sections))) => {
-            outputer.info(task_formatter.display_numbered_task(&task, use_sections))
+            outputer.info(&task_formatter.display_numbered_task(&task, use_sections))
         }
         _ => (),
     };

--- a/src/cmd_edit.rs
+++ b/src/cmd_edit.rs
@@ -20,11 +20,7 @@ pub fn cmd(
     if let Ok(mut child) = Command::new(editor).arg(str_file_path).spawn() {
         match child.wait() {
             Ok(_) => {
-                match user_cmd_runner.build(
-                    String::from("edit"),
-                    String::from("EDIT"),
-                    String::from("Manually edited tasks"),
-                ) {
+                match user_cmd_runner.build("edit", "EDIT", "Manually edited tasks") {
                     Ok(Some(mut cmd)) => {
                         user_cmd_runner.run(&mut cmd)?;
                     }

--- a/src/cmd_focus.rs
+++ b/src/cmd_focus.rs
@@ -10,7 +10,7 @@ pub fn cmd(
     rank_one_based: usize,
     focus: bool,
 ) -> Result<(), String> {
-    let (tasks, use_sections, _) = get_all_tasks(content_getter)?;
+    let (tasks, use_sections, _, _) = get_all_tasks(content_getter)?;
     if rank_one_based > tasks.len() {
         return Err(format!("Non existent task {}", rank_one_based));
     }

--- a/src/cmd_focus.rs
+++ b/src/cmd_focus.rs
@@ -1,7 +1,5 @@
 use crate::services::{ContentGetter, ContentSetter, StringOutputer, TaskFormatter, UserCmdRunner};
-use crate::tasks::{
-    get_all_tasks, task_to_markdown, text_add_focus, text_replace_line_in_contents,
-};
+use crate::tasks::{get_all_tasks, task_to_markdown, text_add_focus, text_replace_line_in_str};
 
 pub fn cmd(
     outputer: &mut dyn StringOutputer,
@@ -12,7 +10,7 @@ pub fn cmd(
     rank_one_based: usize,
     focus: bool,
 ) -> Result<(), String> {
-    let (tasks, use_sections) = get_all_tasks(content_getter)?;
+    let (tasks, use_sections, _) = get_all_tasks(content_getter)?;
     if rank_one_based > tasks.len() {
         return Err(format!("Non existent task {}", rank_one_based));
     }
@@ -51,8 +49,11 @@ pub fn cmd(
 
     updated_task.line = task_to_markdown(&updated_task);
 
-    let replaced_content =
-        text_replace_line_in_contents(content_getter, task.line_num, updated_task.line.clone())?;
+    let replaced_content = text_replace_line_in_str(
+        &content_getter.get_contents()?,
+        task.line_num,
+        &updated_task.line,
+    );
 
     let result = content_setter.set_contents(replaced_content);
 

--- a/src/cmd_focus.rs
+++ b/src/cmd_focus.rs
@@ -18,7 +18,7 @@ pub fn cmd(
     let task = &tasks[rank_one_based - 1];
 
     if task.is_checked {
-        outputer.info(format!(
+        outputer.info(&format!(
             "Task is completed, cannot proceed: {}",
             task_formatter.display_numbered_task(&task, use_sections)
         ));
@@ -26,13 +26,13 @@ pub fn cmd(
     }
 
     if focus && task.is_focused {
-        outputer.info(format!(
+        outputer.info(&format!(
             "Already focused: {}",
             task_formatter.display_numbered_task(&task, use_sections)
         ));
         return Ok(());
     } else if !focus && !task.is_focused {
-        outputer.info(format!(
+        outputer.info(&format!(
             "Already blured: {}",
             task_formatter.display_numbered_task(&task, use_sections)
         ));
@@ -58,23 +58,23 @@ pub fn cmd(
     let result = content_setter.set_contents(replaced_content);
 
     let action = if focus { "Focused" } else { "Blurred" };
-    outputer.info(format!(
+    outputer.info(&format!(
         "{}: {}",
         action,
         task_formatter.display_numbered_task(&updated_task, use_sections)
     ));
 
     match user_cmd_runner.build(
-        String::from("focus"),
-        String::from(if focus { "FOCUS" } else { "BLUR" }),
-        format!(
+        "focus",
+        if focus { "FOCUS" } else { "BLUR" },
+        &format!(
             "{} \"{}\"",
             if focus { "Focused" } else { "Blurred" },
             task.name
         ),
     ) {
         Ok(Some(mut cmd)) => {
-            user_cmd_runner.run(user_cmd_runner.env_single_task(updated_task, &mut cmd))?;
+            user_cmd_runner.run(user_cmd_runner.env_single_task(&updated_task, &mut cmd))?;
         }
         Ok(None) => (),
         Err(e) => return Err(e),

--- a/src/cmd_focus.rs
+++ b/src/cmd_focus.rs
@@ -6,13 +6,13 @@ use crate::tasks::{
 pub fn cmd(
     outputer: &mut dyn StringOutputer,
     content_getter: &dyn ContentGetter,
-    content_setter: &dyn ContentSetter,
+    content_setter: &mut dyn ContentSetter,
     user_cmd_runner: &dyn UserCmdRunner,
     task_formatter: &TaskFormatter,
     rank_one_based: usize,
     focus: bool,
 ) -> Result<(), String> {
-    let tasks = get_all_tasks(content_getter)?;
+    let (tasks, _) = get_all_tasks(content_getter)?;
     if rank_one_based > tasks.len() {
         return Err(format!("Non existent task {}", rank_one_based));
     }

--- a/src/cmd_focus.rs
+++ b/src/cmd_focus.rs
@@ -12,7 +12,7 @@ pub fn cmd(
     rank_one_based: usize,
     focus: bool,
 ) -> Result<(), String> {
-    let (tasks, _) = get_all_tasks(content_getter)?;
+    let (tasks, use_sections) = get_all_tasks(content_getter)?;
     if rank_one_based > tasks.len() {
         return Err(format!("Non existent task {}", rank_one_based));
     }
@@ -22,7 +22,7 @@ pub fn cmd(
     if task.is_checked {
         outputer.info(format!(
             "Task is completed, cannot proceed: {}",
-            task_formatter.display_numbered_task(&task)
+            task_formatter.display_numbered_task(&task, use_sections)
         ));
         return Ok(());
     }
@@ -30,13 +30,13 @@ pub fn cmd(
     if focus && task.is_focused {
         outputer.info(format!(
             "Already focused: {}",
-            task_formatter.display_numbered_task(&task)
+            task_formatter.display_numbered_task(&task, use_sections)
         ));
         return Ok(());
     } else if !focus && !task.is_focused {
         outputer.info(format!(
             "Already blured: {}",
-            task_formatter.display_numbered_task(&task)
+            task_formatter.display_numbered_task(&task, use_sections)
         ));
         return Ok(());
     }
@@ -60,7 +60,7 @@ pub fn cmd(
     outputer.info(format!(
         "{}: {}",
         action,
-        task_formatter.display_numbered_task(&updated_task)
+        task_formatter.display_numbered_task(&updated_task, use_sections)
     ));
 
     match user_cmd_runner.build(

--- a/src/cmd_focus_section.rs
+++ b/src/cmd_focus_section.rs
@@ -1,0 +1,91 @@
+use crate::model::Section;
+use crate::services::{ContentGetter, ContentSetter, StringOutputer, UserCmdRunner};
+use crate::tasks::{get_all_tasks, section_to_markdown, text_replace_line_in_str};
+use std::rc::Rc;
+
+pub fn cmd(
+    outputer: &mut dyn StringOutputer,
+    content_getter: &dyn ContentGetter,
+    content_setter: &mut dyn ContentSetter,
+    _user_cmd_runner: &dyn UserCmdRunner,
+    section_name: String,
+    focus: bool,
+) -> Result<(), String> {
+    let (_, _, sections) = get_all_tasks(content_getter)?;
+
+    let section = match search_section(section_name.as_ref(), &sections) {
+        None => return Err(format!("Section not found: {}", section_name)),
+        Some(section) => section,
+    };
+
+    if focus && section.is_focused {
+        outputer.info(format!("Already focused: {}", section.plain_name));
+        return Ok(());
+    } else if !focus && !section.is_focused {
+        outputer.info(format!("Already blured: {}", section.plain_name));
+        return Ok(());
+    }
+
+    let mut updated_section = section.clone();
+    updated_section.is_focused = focus;
+    updated_section.line = section_to_markdown(&updated_section);
+
+    outputer.info(format!(
+        "{}: {}",
+        if focus { "Focused" } else { "Blurred" },
+        &section.plain_name
+    ));
+
+    let mut replaced_content = text_replace_line_in_str(
+        &content_getter.get_contents()?,
+        section.line_num,
+        &updated_section.line,
+    );
+
+    // blur other focused sections
+
+    for section_rc in sections {
+        let section_cur = section_rc.as_ref();
+        if section_cur.num == section.num {
+            continue;
+        }
+
+        if section_cur.is_focused {
+            let mut updated_section = section_cur.clone();
+            updated_section.is_focused = false;
+            let updated_line = section_to_markdown(&updated_section);
+
+            replaced_content =
+                text_replace_line_in_str(&replaced_content, updated_section.line_num, &updated_line)
+        }
+    }
+
+    content_setter.set_contents(replaced_content)
+}
+
+fn search_section(search: &str, sections: &Vec<Rc<Section>>) -> Option<Section> {
+    let section_name_lower = search.to_lowercase();
+
+    let mut partial_match: Option<Section> = None;
+    let mut exact_match: Option<Section> = None;
+
+    for section_rc in sections {
+        let section_cur = section_rc.as_ref();
+        let section_cur_name_lower = section_cur.name.to_lowercase();
+
+        if section_cur_name_lower == section_name_lower {
+            exact_match = Some(section_cur.clone());
+            break;
+        } else if section_cur_name_lower.contains(&section_name_lower) {
+            partial_match = Some(section_cur.clone());
+        }
+    }
+
+    match exact_match {
+        None => match partial_match {
+            None => None,
+            Some(section) => Some(section),
+        },
+        Some(section) => Some(section),
+    }
+}

--- a/src/cmd_focus_section.rs
+++ b/src/cmd_focus_section.rs
@@ -1,7 +1,5 @@
-use crate::model::Section;
 use crate::services::{ContentGetter, ContentSetter, StringOutputer, UserCmdRunner};
-use crate::tasks::{get_all_tasks, section_to_markdown, text_replace_line_in_str};
-use std::rc::Rc;
+use crate::tasks::{get_all_tasks, search_section, section_to_markdown, text_replace_line_in_str};
 
 pub fn cmd(
     outputer: &mut dyn StringOutputer,
@@ -11,7 +9,7 @@ pub fn cmd(
     section_name: String,
     focus: bool,
 ) -> Result<(), String> {
-    let (_, _, sections) = get_all_tasks(content_getter)?;
+    let (_, _, sections, _) = get_all_tasks(content_getter)?;
 
     let section = match search_section(section_name.as_ref(), &sections) {
         None => return Err(format!("Section not found: {}", section_name)),
@@ -61,31 +59,4 @@ pub fn cmd(
     }
 
     content_setter.set_contents(replaced_content)
-}
-
-fn search_section(search: &str, sections: &Vec<Rc<Section>>) -> Option<Section> {
-    let section_name_lower = search.to_lowercase();
-
-    let mut partial_match: Option<Section> = None;
-    let mut exact_match: Option<Section> = None;
-
-    for section_rc in sections {
-        let section_cur = section_rc.as_ref();
-        let section_cur_name_lower = section_cur.name.to_lowercase();
-
-        if section_cur_name_lower == section_name_lower {
-            exact_match = Some(section_cur.clone());
-            break;
-        } else if section_cur_name_lower.contains(&section_name_lower) {
-            partial_match = Some(section_cur.clone());
-        }
-    }
-
-    match exact_match {
-        None => match partial_match {
-            None => None,
-            Some(section) => Some(section),
-        },
-        Some(section) => Some(section),
-    }
 }

--- a/src/cmd_focus_section.rs
+++ b/src/cmd_focus_section.rs
@@ -17,10 +17,10 @@ pub fn cmd(
     };
 
     if focus && section.is_focused {
-        outputer.info(format!("Already focused: {}", section.plain_name));
+        outputer.info(&format!("Already focused: {}", section.plain_name));
         return Ok(());
     } else if !focus && !section.is_focused {
-        outputer.info(format!("Already blured: {}", section.plain_name));
+        outputer.info(&format!("Already blured: {}", section.plain_name));
         return Ok(());
     }
 
@@ -28,7 +28,7 @@ pub fn cmd(
     updated_section.is_focused = focus;
     updated_section.line = section_to_markdown(&updated_section);
 
-    outputer.info(format!(
+    outputer.info(&format!(
         "{}: {}",
         if focus { "Focused" } else { "Blurred" },
         &section.plain_name

--- a/src/cmd_list.rs
+++ b/src/cmd_list.rs
@@ -9,7 +9,7 @@ pub fn cmd(
     content_getter: &dyn ContentGetter,
     task_formatter: &TaskFormatter,
 ) -> Result<(), String> {
-    let (tasks, use_sections) = get_open_tasks(content_getter)?;
+    let (tasks, use_sections, _) = get_open_tasks(content_getter)?;
     // let mut current_section: Option<Rc<Section>> = None;
     let mut section_num = 0;
 
@@ -49,7 +49,7 @@ mod tests {
         // Empty contents
         {
             let outputer_mock = &mut StringOutputerMock::new();
-            let content_getter_mock = &ContentGetterMock::new(Ok(Vec::new()));
+            let content_getter_mock = &ContentGetterMock::new(Ok("".to_string()));
 
             cmd(outputer_mock, content_getter_mock, task_formatter).unwrap();
             assert_eq!(outputer_mock.get_info(), "");

--- a/src/cmd_list.rs
+++ b/src/cmd_list.rs
@@ -30,7 +30,7 @@ pub fn cmd(
                 }
             }
         }
-        outputer.info(task_formatter.display_numbered_task(&task))
+        outputer.info(task_formatter.display_numbered_task(&task, false))
     }
 
     Ok(())

--- a/src/cmd_prune.rs
+++ b/src/cmd_prune.rs
@@ -1,5 +1,5 @@
 use crate::services::{ContentGetter, ContentSetter, StringOutputer, TaskFormatter, UserCmdRunner};
-use crate::tasks::{get_closed_tasks, text_remove_lines_in_contents};
+use crate::tasks::{get_closed_tasks, text_remove_lines_in_str};
 
 pub fn cmd(
     outputer: &mut dyn StringOutputer,
@@ -8,7 +8,7 @@ pub fn cmd(
     user_cmd_runner: &dyn UserCmdRunner,
     task_formatter: &TaskFormatter,
 ) -> Result<(), String> {
-    let (tasks, use_sections) = get_closed_tasks(content_getter)?;
+    let (tasks, use_sections, _) = get_closed_tasks(content_getter)?;
 
     if tasks.len() == 0 {
         outputer.info("No task to prune".to_string());
@@ -16,7 +16,7 @@ pub fn cmd(
     }
 
     let line_nums: Vec<usize> = (&tasks).into_iter().map(|t| t.line_num).collect();
-    let pruned_content = text_remove_lines_in_contents(content_getter, line_nums)?;
+    let pruned_content = text_remove_lines_in_str(&content_getter.get_contents()?, line_nums)?;
 
     content_setter.set_contents(pruned_content)?;
 

--- a/src/cmd_prune.rs
+++ b/src/cmd_prune.rs
@@ -8,7 +8,7 @@ pub fn cmd(
     user_cmd_runner: &dyn UserCmdRunner,
     task_formatter: &TaskFormatter,
 ) -> Result<(), String> {
-    let (tasks, use_sections, _) = get_closed_tasks(content_getter)?;
+    let (tasks, use_sections, _, _) = get_closed_tasks(content_getter)?;
 
     if tasks.len() == 0 {
         outputer.info("No task to prune".to_string());

--- a/src/cmd_prune.rs
+++ b/src/cmd_prune.rs
@@ -8,7 +8,7 @@ pub fn cmd(
     user_cmd_runner: &dyn UserCmdRunner,
     task_formatter: &TaskFormatter,
 ) -> Result<(), String> {
-    let (tasks, _) = get_closed_tasks(content_getter)?;
+    let (tasks, use_sections) = get_closed_tasks(content_getter)?;
 
     if tasks.len() == 0 {
         outputer.info("No task to prune".to_string());
@@ -29,7 +29,7 @@ pub fn cmd(
     outputer.info(msg.clone());
 
     for task in &tasks {
-        outputer.info(task_formatter.display_numbered_task(&task))
+        outputer.info(task_formatter.display_numbered_task(&task, use_sections))
     }
 
     match user_cmd_runner.build(String::from("prune"), String::from("PRUNE"), msg) {

--- a/src/cmd_prune.rs
+++ b/src/cmd_prune.rs
@@ -4,11 +4,11 @@ use crate::tasks::{get_closed_tasks, text_remove_lines_in_contents};
 pub fn cmd(
     outputer: &mut dyn StringOutputer,
     content_getter: &dyn ContentGetter,
-    content_setter: &dyn ContentSetter,
+    content_setter: &mut dyn ContentSetter,
     user_cmd_runner: &dyn UserCmdRunner,
     task_formatter: &TaskFormatter,
 ) -> Result<(), String> {
-    let tasks = get_closed_tasks(content_getter)?;
+    let (tasks, _) = get_closed_tasks(content_getter)?;
 
     if tasks.len() == 0 {
         outputer.info("No task to prune".to_string());

--- a/src/cmd_prune.rs
+++ b/src/cmd_prune.rs
@@ -11,7 +11,7 @@ pub fn cmd(
     let (tasks, use_sections, _, _) = get_closed_tasks(content_getter)?;
 
     if tasks.len() == 0 {
-        outputer.info("No task to prune".to_string());
+        outputer.info("No task to prune");
         return Ok(());
     }
 
@@ -26,13 +26,13 @@ pub fn cmd(
         if tasks.len() > 1 { "s" } else { "" }
     );
 
-    outputer.info(msg.clone());
+    outputer.info(&msg);
 
     for task in &tasks {
-        outputer.info(task_formatter.display_numbered_task(&task, use_sections))
+        outputer.info(&task_formatter.display_numbered_task(&task, use_sections))
     }
 
-    match user_cmd_runner.build(String::from("prune"), String::from("PRUNE"), msg) {
+    match user_cmd_runner.build("prune", "PRUNE", &msg) {
         Ok(Some(mut cmd)) => {
             user_cmd_runner.run(&mut cmd)?;
         }

--- a/src/cmd_which.rs
+++ b/src/cmd_which.rs
@@ -4,6 +4,6 @@ pub fn cmd(
     outputer: &mut dyn StringOutputer,
     taxfile_path_getter: &dyn TaxfilePathGetter,
 ) -> Result<(), String> {
-    outputer.info(taxfile_path_getter.get_taxfile_path()?);
+    outputer.info(&taxfile_path_getter.get_taxfile_path()?);
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,11 @@ fn run_app(matches: ArgMatches) -> Result<(), String> {
     };
 
     let file_path = taxfile_path_getter.get_taxfile_path()?;
-    let content_handler = &ContentHandlerReal { path: file_path };
+
+    let content_handler_ref = &ContentHandlerReal {
+        path: file_path.clone(),
+    };
+    let content_handler_mutref = &mut ContentHandlerReal { path: file_path };
 
     let outputer = &mut StringOutputerReal {};
 
@@ -139,12 +143,12 @@ fn run_app(matches: ArgMatches) -> Result<(), String> {
     };
 
     match matches.subcommand() {
-        (_, None) => cmd_list::cmd(outputer, content_handler, task_formatter),
+        (_, None) => cmd_list::cmd(outputer, content_handler_ref, task_formatter),
         ("edit", _) => cmd_edit::cmd(taxfile_path_getter, user_cmd_runner),
         ("focus", Some(info)) => cmd_focus::cmd(
             outputer,
-            content_handler,
-            content_handler,
+            content_handler_ref,
+            content_handler_mutref,
             user_cmd_runner,
             task_formatter,
             value_t!(info.value_of("task-index"), usize).unwrap(),
@@ -152,8 +156,8 @@ fn run_app(matches: ArgMatches) -> Result<(), String> {
         ),
         ("blur", Some(info)) => cmd_focus::cmd(
             outputer,
-            content_handler,
-            content_handler,
+            content_handler_ref,
+            content_handler_mutref,
             user_cmd_runner,
             task_formatter,
             value_t!(info.value_of("task-index"), usize).unwrap(),
@@ -162,8 +166,8 @@ fn run_app(matches: ArgMatches) -> Result<(), String> {
 
         ("check", Some(info)) => cmd_check::cmd(
             outputer,
-            content_handler,
-            content_handler,
+            content_handler_ref,
+            content_handler_mutref,
             user_cmd_runner,
             task_formatter,
             value_t!(info.value_of("task-index"), usize).unwrap(),
@@ -171,34 +175,34 @@ fn run_app(matches: ArgMatches) -> Result<(), String> {
         ),
         ("uncheck", Some(info)) => cmd_check::cmd(
             outputer,
-            content_handler,
-            content_handler,
+            content_handler_ref,
+            content_handler_mutref,
             user_cmd_runner,
             task_formatter,
             value_t!(info.value_of("task-index"), usize).unwrap(),
             false,
         ),
 
-        ("list", _) => cmd_list::cmd(outputer, content_handler, task_formatter),
-        ("current", _) => cmd_current::cmd(outputer, content_handler, task_formatter, false),
-        ("cycle", _) => cmd_current::cmd(outputer, content_handler, task_formatter, true),
+        ("list", _) => cmd_list::cmd(outputer, content_handler_ref, task_formatter),
+        ("current", _) => cmd_current::cmd(outputer, content_handler_ref, task_formatter, false),
+        ("cycle", _) => cmd_current::cmd(outputer, content_handler_ref, task_formatter, true),
 
         ("prune", _) => cmd_prune::cmd(
             outputer,
-            content_handler,
-            content_handler,
+            content_handler_ref,
+            content_handler_mutref,
             user_cmd_runner,
             task_formatter,
         ),
 
-        ("cat", _) => cmd_cat::cmd(outputer, content_handler),
+        ("cat", _) => cmd_cat::cmd(outputer, content_handler_ref),
 
         ("which", _) => cmd_which::cmd(outputer, taxfile_path_getter),
 
         ("add", Some(info)) => cmd_add::cmd(
             outputer,
-            content_handler,
-            content_handler,
+            content_handler_ref,
+            content_handler_mutref,
             user_cmd_runner,
             task_formatter,
             info.values_of_lossy("task-name").unwrap(),
@@ -207,8 +211,8 @@ fn run_app(matches: ArgMatches) -> Result<(), String> {
 
         ("append", Some(info)) => cmd_add::cmd(
             outputer,
-            content_handler,
-            content_handler,
+            content_handler_ref,
+            content_handler_mutref,
             user_cmd_runner,
             task_formatter,
             info.values_of_lossy("task-name").unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod cmd_check;
 mod cmd_current;
 mod cmd_edit;
 mod cmd_focus;
+mod cmd_focus_section;
 mod cmd_list;
 mod cmd_prune;
 mod cmd_which;
@@ -145,24 +146,52 @@ fn run_app(matches: ArgMatches) -> Result<(), String> {
     match matches.subcommand() {
         (_, None) => cmd_list::cmd(outputer, content_handler_ref, task_formatter),
         ("edit", _) => cmd_edit::cmd(taxfile_path_getter, user_cmd_runner),
-        ("focus", Some(info)) => cmd_focus::cmd(
-            outputer,
-            content_handler_ref,
-            content_handler_mutref,
-            user_cmd_runner,
-            task_formatter,
-            value_t!(info.value_of("task-index"), usize).unwrap(),
-            true,
-        ),
-        ("blur", Some(info)) => cmd_focus::cmd(
-            outputer,
-            content_handler_ref,
-            content_handler_mutref,
-            user_cmd_runner,
-            task_formatter,
-            value_t!(info.value_of("task-index"), usize).unwrap(),
-            false,
-        ),
+        ("focus", Some(info)) => {
+            let to_focus = info.value_of("task-index").unwrap();
+
+            return match to_focus.parse::<usize>() {
+                Ok(rank_one_based) => cmd_focus::cmd(
+                    outputer,
+                    content_handler_ref,
+                    content_handler_mutref,
+                    user_cmd_runner,
+                    task_formatter,
+                    rank_one_based,
+                    true,
+                ),
+                Err(_) => cmd_focus_section::cmd(
+                    outputer,
+                    content_handler_ref,
+                    content_handler_mutref,
+                    user_cmd_runner,
+                    to_focus.to_string(),
+                    true,
+                ),
+            };
+        }
+        ("blur", Some(info)) => {
+            let to_focus = info.value_of("task-index").unwrap();
+
+            return match to_focus.parse::<usize>() {
+                Ok(rank_one_based) => cmd_focus::cmd(
+                    outputer,
+                    content_handler_ref,
+                    content_handler_mutref,
+                    user_cmd_runner,
+                    task_formatter,
+                    rank_one_based,
+                    false,
+                ),
+                Err(_) => cmd_focus_section::cmd(
+                    outputer,
+                    content_handler_ref,
+                    content_handler_mutref,
+                    user_cmd_runner,
+                    to_focus.to_string(),
+                    false,
+                ),
+            };
+        }
 
         ("check", Some(info)) => cmd_check::cmd(
             outputer,

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,8 +98,14 @@ fn get_arg_matches() -> ArgMatches<'static> {
                 .alias("prepend")
                 .about("Add the given task at the top of the task list")
                 .arg(
+                    Arg::with_name("section")
+                        .short("s")
+                        .long("section")
+                        .takes_value(true)
+                        .help("Section where to add task"),
+                )
+                .arg(
                     Arg::with_name("task-name")
-                        .index(1)
                         .required(true)
                         .multiple(true)
                         .help("Name of the task to add"),
@@ -109,8 +115,14 @@ fn get_arg_matches() -> ArgMatches<'static> {
             App::new("append")
                 .about("Add the given task at the bottom of the task list")
                 .arg(
+                    Arg::with_name("section")
+                        .short("s")
+                        .long("section")
+                        .takes_value(true)
+                        .help("Section where to add task"),
+                )
+                .arg(
                     Arg::with_name("task-name")
-                        .index(1)
                         .required(true)
                         .multiple(true)
                         .help("Name of the task to add"),
@@ -235,6 +247,10 @@ fn run_app(matches: ArgMatches) -> Result<(), String> {
             user_cmd_runner,
             task_formatter,
             info.values_of_lossy("task-name").unwrap(),
+            match info.value_of_lossy("section") {
+                None => None,
+                Some(s) => Some(s.to_string()),
+            },
             cmd_add::AddPosition::Prepend,
         ),
 
@@ -245,6 +261,10 @@ fn run_app(matches: ArgMatches) -> Result<(), String> {
             user_cmd_runner,
             task_formatter,
             info.values_of_lossy("task-name").unwrap(),
+            match info.value_of_lossy("section") {
+                None => None,
+                Some(s) => Some(s.to_string()),
+            },
             cmd_add::AddPosition::Append,
         ),
         _ => Err(format!("Unknown command")),

--- a/src/model.rs
+++ b/src/model.rs
@@ -20,6 +20,7 @@ pub struct Section {
     pub plain_name: String,
     pub is_focused: bool,
     pub line_num: usize,
+    pub line_num_end: usize,
     pub line: String,
     pub level: usize,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 #[derive(std::clone::Clone, Debug, PartialEq)]
 pub struct Task {
     pub num: usize,
@@ -8,4 +10,13 @@ pub struct Task {
     pub line_num: usize,
     pub line: String,
     pub is_focused: bool,
+    pub section: Option<Rc<Section>>,
+}
+
+#[derive(std::clone::Clone, Debug, PartialEq)]
+pub struct Section {
+    pub num: usize,
+    pub name: String,
+    pub line_num: usize,
+    pub line: String,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -17,6 +17,9 @@ pub struct Task {
 pub struct Section {
     pub num: usize,
     pub name: String,
+    pub plain_name: String,
+    pub is_focused: bool,
     pub line_num: usize,
     pub line: String,
+    pub level: usize,
 }

--- a/src/services.rs
+++ b/src/services.rs
@@ -11,11 +11,22 @@ pub struct TaskFormatter {
     pub supports_colors: bool,
 }
 impl TaskFormatter {
+    #[allow(dead_code)]
+    pub fn new(supports_colors: bool) -> Self {
+        TaskFormatter {
+            supports_colors: supports_colors,
+        }
+    }
+
     pub fn display_numbered_task(&self, task: &Task) -> String {
         format!(
             "{} {}",
             self.display_task_num(task),
-            self.display_task_name(task)
+            self.display_task_name(task),
+            // match &task.section {
+            //     Some(rc) => rc.name.clone(),
+            //     None => String::from(""),
+            // },
         )
     }
 
@@ -126,11 +137,11 @@ impl ContentGetter for ContentHandlerReal {
 }
 
 pub trait ContentSetter {
-    fn set_contents(&self, contents: String) -> Result<(), String>;
+    fn set_contents(&mut self, contents: String) -> Result<(), String>;
 }
 
 impl ContentSetter for ContentHandlerReal {
-    fn set_contents(&self, contents: String) -> Result<(), String> {
+    fn set_contents(&mut self, contents: String) -> Result<(), String> {
         match fs::write(&self.path, contents) {
             Ok(_) => Ok(()),
             Err(_) => Err(String::from("Unable to write file")),
@@ -224,7 +235,7 @@ fn get_env_var_if_not_empty(name: &str, get_env: EnvGetter) -> Option<String> {
 mod tests {
 
     use super::*;
-    use crate::test_helpers::{env_getter_none, env_getter_taxfile, home_getter_guybrush};
+    use crate::test_helpers::test::{env_getter_none, env_getter_taxfile, home_getter_guybrush};
 
     #[test]
     fn test_taxfile_path_getter_real() {

--- a/src/services.rs
+++ b/src/services.rs
@@ -75,12 +75,12 @@ impl TaskFormatter {
 }
 
 pub trait StringOutputer {
-    fn info(&mut self, s: String) -> ();
+    fn info(&mut self, s: &str) -> ();
 }
 
 pub struct StringOutputerReal {}
 impl StringOutputer for StringOutputerReal {
-    fn info(&mut self, s: String) -> () {
+    fn info(&mut self, s: &str) -> () {
         println!("{}", s);
     }
 }
@@ -175,18 +175,13 @@ pub struct UserCmdRunnerReal {
 }
 
 pub trait UserCmdRunner {
-    fn env_single_task<'a>(&self, task: Task, cmd: &'a mut Command) -> &'a mut Command;
-    fn build(
-        &self,
-        cmd: String,
-        operation: String,
-        message: String,
-    ) -> Result<Option<Command>, String>;
+    fn env_single_task<'a>(&self, task: &Task, cmd: &'a mut Command) -> &'a mut Command;
+    fn build(&self, cmd: &str, operation: &str, message: &str) -> Result<Option<Command>, String>;
     fn run(&self, cmd: &mut Command) -> Result<(), String>;
 }
 
 impl UserCmdRunner for UserCmdRunnerReal {
-    fn env_single_task<'a>(&self, task: Task, cmd: &'a mut Command) -> &'a mut Command {
+    fn env_single_task<'a>(&self, task: &Task, cmd: &'a mut Command) -> &'a mut Command {
         cmd.env("TAX_TASK_NUM", format!("{}", task.num))
             .env("TAX_TASK_NAME", &task.name)
             .env("TAX_TASK_PLAIN_NAME", &task.plain_name)
@@ -196,12 +191,7 @@ impl UserCmdRunner for UserCmdRunnerReal {
             .env("TAX_TASK_FOCUSED", if task.is_focused { "1" } else { "0" })
     }
 
-    fn build(
-        &self,
-        cmd: String,
-        operation: String,
-        message: String,
-    ) -> Result<Option<Command>, String> {
+    fn build(&self, cmd: &str, operation: &str, message: &str) -> Result<Option<Command>, String> {
         let sh_path = match which::which("sh") {
             Ok(path) => path,
             Err(_) => return Err(String::from("Could not find sh")),

--- a/src/services.rs
+++ b/src/services.rs
@@ -28,7 +28,7 @@ impl TaskFormatter {
                     Some(rc) => format!(
                         " ~ {}",
                         if task.section.as_ref().unwrap().is_focused {
-                            self.display_bold(rc.plain_name.clone())
+                            self.display_bold(&rc.plain_name)
                         } else {
                             rc.plain_name.clone()
                         }
@@ -41,9 +41,17 @@ impl TaskFormatter {
         )
     }
 
-    fn display_bold(&self, s: String) -> String {
+    pub fn display_bold_color_only(&self, s: &str) -> String {
         if self.supports_colors {
-            s.clone().bold().to_string()
+            s.bold().to_string()
+        } else {
+            s.to_string()
+        }
+    }
+
+    pub fn display_bold(&self, s: &str) -> String {
+        if self.supports_colors {
+            s.bold().to_string()
         } else {
             format!("**{}**", s)
         }
@@ -51,7 +59,7 @@ impl TaskFormatter {
 
     pub fn display_task_name(&self, task: &Task) -> String {
         if task.is_focused {
-            self.display_bold(task.plain_name.clone())
+            self.display_bold(&task.plain_name)
         } else {
             task.name.clone()
         }
@@ -59,7 +67,7 @@ impl TaskFormatter {
 
     pub fn display_task_num(&self, task: &Task) -> String {
         if task.is_focused && self.supports_colors {
-            format!("[{}]", self.display_bold(format!("{}", task.num)))
+            format!("[{}]", self.display_bold(&format!("{}", task.num)))
         } else {
             format!("[{}]", task.num)
         }

--- a/src/services.rs
+++ b/src/services.rs
@@ -18,15 +18,19 @@ impl TaskFormatter {
         }
     }
 
-    pub fn display_numbered_task(&self, task: &Task) -> String {
+    pub fn display_numbered_task(&self, task: &Task, use_sections: bool) -> String {
         format!(
-            "{} {}",
+            "{} {}{}",
             self.display_task_num(task),
             self.display_task_name(task),
-            // match &task.section {
-            //     Some(rc) => rc.name.clone(),
-            //     None => String::from(""),
-            // },
+            if use_sections {
+                match &task.section {
+                    Some(rc) => format!(" ~ {}", rc.name.clone()),
+                    None => String::from(""),
+                }
+            } else {
+                "".to_string()
+            },
         )
     }
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -15,10 +15,10 @@ lazy_static! {
 pub fn get_current_task(
     content_getter: &dyn ContentGetter,
     cycle: bool,
-) -> Result<Option<Task>, String> {
-    let (focused_tasks, _) = get_focused_open_tasks(content_getter)?;
+) -> Result<Option<(Task, bool)>, String> {
+    let (focused_tasks, use_sections) = get_focused_open_tasks(content_getter)?;
     if focused_tasks.len() > 0 {
-        return Ok(Some(focused_tasks[0].clone()));
+        return Ok(Some((focused_tasks[0].clone(), use_sections)));
     }
 
     let (tasks, _) = get_open_tasks(content_getter)?;
@@ -35,10 +35,13 @@ pub fn get_current_task(
 
         // select task based on minute for
         // stateless stable rotation of displayed tasks
-        return Ok(Some(tasks[minutes as usize % tasks.len()].clone()));
+        return Ok(Some((
+            tasks[minutes as usize % tasks.len()].clone(),
+            use_sections,
+        )));
     }
 
-    Ok(Some(tasks[0].clone()))
+    Ok(Some((tasks[0].clone(), use_sections)))
 }
 
 pub fn get_all_tasks(content_getter: &dyn ContentGetter) -> Result<(Vec<Task>, bool), String> {
@@ -357,7 +360,7 @@ mod tests {
         let (test_contents, expected_tasks) = get_std_test_contents();
 
         match get_current_task(&ContentGetterMock::new(Ok(test_contents)), false) {
-            Ok(task) => assert_eq!(task, Some(expected_tasks[1].clone())),
+            Ok(task) => assert_eq!(task, Some((expected_tasks[1].clone(), false))),
             Err(e) => panic!(e),
         }
     }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -9,19 +9,19 @@ lazy_static! {
         Regex::new(r"(?m)^\s*(?:-|\*)\s+\[(x|\s*|>)\]\s+(.+?)$").unwrap();
     static ref TASK_NAME_FOCUSED_REGEX: Regex = Regex::new(r"(?m)\*\*.+\*\*").unwrap();
     static ref COMMENT_REGEX: Regex = Regex::new(r"(?m)^(.*?)[^:]//(.+?)$").unwrap();
-    static ref HEADER_REGEX: Regex = Regex::new(r"(?m)^#{1,6}\s+(.*?)$").unwrap();
+    static ref HEADER_REGEX: Regex = Regex::new(r"(?m)^(#{1,6})\s+(.*?)$").unwrap();
 }
 
 pub fn get_current_task(
     content_getter: &dyn ContentGetter,
     cycle: bool,
 ) -> Result<Option<(Task, bool)>, String> {
-    let (focused_tasks, use_sections) = get_focused_open_tasks(content_getter)?;
+    let (focused_tasks, use_sections, _) = get_focused_open_tasks(content_getter)?;
     if focused_tasks.len() > 0 {
         return Ok(Some((focused_tasks[0].clone(), use_sections)));
     }
 
-    let (tasks, _) = get_open_tasks(content_getter)?;
+    let (tasks, _, _) = get_open_tasks(content_getter)?;
     if tasks.len() == 0 {
         return Ok(None);
     }
@@ -44,7 +44,9 @@ pub fn get_current_task(
     Ok(Some((tasks[0].clone(), use_sections)))
 }
 
-pub fn get_all_tasks(content_getter: &dyn ContentGetter) -> Result<(Vec<Task>, bool), String> {
+pub fn get_all_tasks(
+    content_getter: &dyn ContentGetter,
+) -> Result<(Vec<Task>, bool, Vec<Rc<Section>>), String> {
     let mut tasks: Vec<Task> = Vec::new();
     let mut sections: Vec<Rc<Section>> = Vec::new();
 
@@ -53,17 +55,27 @@ pub fn get_all_tasks(content_getter: &dyn ContentGetter) -> Result<(Vec<Task>, b
     let mut line_num = 1;
     let mut current_section: Option<Rc<Section>> = None;
 
-    for line in content_getter.get_contents()? {
-        let l_str = line.as_str();
-
-        match HEADER_REGEX.captures(l_str) {
+    for line in content_getter.get_contents()?.lines() {
+        match HEADER_REGEX.captures(line) {
             None => (),
             Some(cap) => {
+                let header_markup = cap[1].trim();
+                let section_name = cap[2].trim();
+                let is_focused = text_is_focused(section_name);
+                let plain_name = if is_focused {
+                    text_remove_focus(section_name)
+                } else {
+                    section_name.to_string()
+                };
+
                 let section = Rc::from(Section {
-                    name: cap[1].trim().to_string(),
+                    name: section_name.to_string(),
+                    plain_name: plain_name,
+                    is_focused: is_focused,
                     num: section_num,
-                    line: line.clone(),
+                    line: line.to_string(),
                     line_num: line_num,
+                    level: header_markup.len(),
                 });
                 sections.push(section.clone());
                 current_section = Some(section);
@@ -74,7 +86,7 @@ pub fn get_all_tasks(content_getter: &dyn ContentGetter) -> Result<(Vec<Task>, b
             }
         };
 
-        match TASK_LINE_REGEX.captures(l_str) {
+        match TASK_LINE_REGEX.captures(line) {
             None => (),
             Some(cap) => {
                 let check_symbol = cap[1].trim();
@@ -95,7 +107,7 @@ pub fn get_all_tasks(content_getter: &dyn ContentGetter) -> Result<(Vec<Task>, b
                     num: task_num,
                     is_checked: text_is_check_symbol(check_symbol),
                     line_num: line_num,
-                    line: String::from(&cap[0]),
+                    line: line.to_string(),
                     is_focused: is_task_focused,
                     section: current_section.clone(),
                 });
@@ -109,24 +121,30 @@ pub fn get_all_tasks(content_getter: &dyn ContentGetter) -> Result<(Vec<Task>, b
 
     let use_section = sections.len() > 1;
 
-    Ok((tasks, use_section))
+    Ok((tasks, use_section, sections))
 }
 
-pub fn get_open_tasks(content_getter: &dyn ContentGetter) -> Result<(Vec<Task>, bool), String> {
+pub fn get_open_tasks(
+    content_getter: &dyn ContentGetter,
+) -> Result<(Vec<Task>, bool, Vec<Rc<Section>>), String> {
     match get_all_tasks(content_getter) {
-        Ok((tasks, use_sections)) => Ok((
+        Ok((tasks, use_sections, sections)) => Ok((
             tasks.into_iter().filter(|task| !task.is_checked).collect(),
             use_sections,
+            sections,
         )),
         Err(msg) => Err(msg),
     }
 }
 
-pub fn get_closed_tasks(content_getter: &dyn ContentGetter) -> Result<(Vec<Task>, bool), String> {
+pub fn get_closed_tasks(
+    content_getter: &dyn ContentGetter,
+) -> Result<(Vec<Task>, bool, Vec<Rc<Section>>), String> {
     match get_all_tasks(content_getter) {
-        Ok((tasks, use_sections)) => Ok((
+        Ok((tasks, use_sections, sections)) => Ok((
             tasks.into_iter().filter(|task| task.is_checked).collect(),
             use_sections,
+            sections,
         )),
         Err(msg) => Err(msg),
     }
@@ -134,11 +152,12 @@ pub fn get_closed_tasks(content_getter: &dyn ContentGetter) -> Result<(Vec<Task>
 
 pub fn get_focused_open_tasks(
     content_getter: &dyn ContentGetter,
-) -> Result<(Vec<Task>, bool), String> {
+) -> Result<(Vec<Task>, bool, Vec<Rc<Section>>), String> {
     match get_open_tasks(content_getter) {
-        Ok((tasks, use_sections)) => Ok((
+        Ok((tasks, use_sections, sections)) => Ok((
             tasks.into_iter().filter(|task| task.is_focused).collect(),
             use_sections,
+            sections,
         )),
         Err(msg) => Err(msg),
     }
@@ -146,6 +165,18 @@ pub fn get_focused_open_tasks(
 
 pub fn text_is_check_symbol(s: &str) -> bool {
     return s == "x";
+}
+
+pub fn section_to_markdown(section: &Section) -> String {
+    format!(
+        "{} {}",
+        "#".repeat(section.level),
+        if section.is_focused {
+            text_add_focus(&section.plain_name)
+        } else {
+            section.plain_name.clone()
+        },
+    )
 }
 
 pub fn task_to_markdown(task: &Task) -> String {
@@ -184,10 +215,7 @@ pub fn text_get_comment(task_name: &str) -> (String, Option<String>) {
     }
 }
 
-pub fn text_remove_lines_in_contents(
-    content_getter: &dyn ContentGetter,
-    line_nums: Vec<usize>,
-) -> Result<String, String> {
+pub fn text_remove_lines_in_str(s: &str, line_nums: Vec<usize>) -> Result<String, String> {
     let mut line_num = 1;
 
     let mut content = String::from("");
@@ -199,7 +227,7 @@ pub fn text_remove_lines_in_contents(
         line_nums_hash.insert(*l, true);
     }
 
-    for line in content_getter.get_contents()? {
+    for line in s.lines() {
         if !line_nums_hash.contains_key(&line_num) {
             content += format!("{}\n", line).as_str();
         }
@@ -210,16 +238,16 @@ pub fn text_remove_lines_in_contents(
     Ok(content)
 }
 
-pub fn text_replace_line_in_contents(
-    content_getter: &dyn ContentGetter,
+pub fn text_replace_line_in_str(
+    s: &str,
     replace_line_num: usize,
-    replacement_line: String,
-) -> Result<String, String> {
+    replacement_line: &String,
+) -> String {
     let mut line_num = 1;
 
     let mut content = String::from("");
 
-    for line in content_getter.get_contents()? {
+    for line in s.lines() {
         if line_num == replace_line_num {
             content += format!("{}\n", replacement_line).as_str();
         } else {
@@ -229,11 +257,11 @@ pub fn text_replace_line_in_contents(
         line_num += 1;
     }
 
-    Ok(content)
+    content
 }
 
-pub fn text_add_line_in_contents(
-    content_getter: &dyn ContentGetter,
+pub fn text_add_line_in_str(
+    s: &str,
     add_line_num: usize,
     added_line: String,
 ) -> Result<String, String> {
@@ -243,7 +271,7 @@ pub fn text_add_line_in_contents(
 
     let mut added = false;
 
-    for line in content_getter.get_contents()? {
+    for line in s.lines() {
         if line_num == add_line_num {
             content += format!("{}\n", added_line).as_str();
             added = true;
@@ -270,10 +298,11 @@ mod tests {
     #[test]
     fn test_task_to_markdown() {
         let (expected_markdown, tasks) = get_std_test_tasks();
+        let lines: Vec<&str> = expected_markdown.lines().collect();
 
         let mut i = 0;
         for task in tasks {
-            assert_eq!(expected_markdown[i].clone(), task_to_markdown(&task));
+            assert_eq!(lines[i].clone(), task_to_markdown(&task));
             i += 1;
         }
     }
@@ -289,8 +318,8 @@ mod tests {
     #[test]
     fn test_get_all_tasks() {
         // Empty contents
-        match get_all_tasks(&ContentGetterMock::new(Ok(Vec::new()))) {
-            Ok((tasks, _)) => assert_eq!(tasks, Vec::new()),
+        match get_all_tasks(&ContentGetterMock::new(Ok("".to_string()))) {
+            Ok((tasks, _, _)) => assert_eq!(tasks, Vec::new()),
             Err(e) => panic!(e),
         }
 
@@ -298,7 +327,7 @@ mod tests {
         let (test_contents, expected_tasks) = get_std_test_contents();
 
         match get_all_tasks(&ContentGetterMock::new(Ok(test_contents))) {
-            Ok((tasks, _)) => assert_eq!(tasks, expected_tasks),
+            Ok((tasks, _, _)) => assert_eq!(tasks, expected_tasks),
             Err(e) => panic!(e),
         }
     }
@@ -306,8 +335,8 @@ mod tests {
     #[test]
     fn test_get_open_tasks() {
         // Empty contents
-        match get_open_tasks(&ContentGetterMock::new(Ok(Vec::new()))) {
-            Ok((tasks, _)) => assert_eq!(tasks, Vec::new()),
+        match get_open_tasks(&ContentGetterMock::new(Ok("".to_string()))) {
+            Ok((tasks, _, _)) => assert_eq!(tasks, Vec::new()),
             Err(e) => panic!(e),
         }
 
@@ -315,7 +344,7 @@ mod tests {
         let (test_contents, expected_tasks) = get_std_test_contents();
 
         match get_open_tasks(&ContentGetterMock::new(Ok(test_contents))) {
-            Ok((tasks, _)) => assert_eq!(
+            Ok((tasks, _, _)) => assert_eq!(
                 tasks,
                 vec![
                     expected_tasks[0].clone(),
@@ -331,8 +360,8 @@ mod tests {
     #[test]
     fn test_get_focused_open_tasks() {
         // Empty contents
-        match get_focused_open_tasks(&ContentGetterMock::new(Ok(Vec::new()))) {
-            Ok((tasks, _)) => assert_eq!(tasks, Vec::new()),
+        match get_focused_open_tasks(&ContentGetterMock::new(Ok("".to_string()))) {
+            Ok((tasks, _, _)) => assert_eq!(tasks, Vec::new()),
             Err(e) => panic!(e),
         }
 
@@ -340,7 +369,7 @@ mod tests {
         let (test_contents, expected_tasks) = get_std_test_contents();
 
         match get_focused_open_tasks(&ContentGetterMock::new(Ok(test_contents))) {
-            Ok((tasks, _)) => assert_eq!(
+            Ok((tasks, _, _)) => assert_eq!(
                 tasks,
                 vec![expected_tasks[1].clone(), expected_tasks[5].clone()]
             ),
@@ -351,7 +380,7 @@ mod tests {
     #[test]
     fn test_get_current_task() {
         // Empty contents
-        match get_current_task(&ContentGetterMock::new(Ok(Vec::new())), false) {
+        match get_current_task(&ContentGetterMock::new(Ok("".to_string())), false) {
             Ok(task) => assert_eq!(task, None),
             Err(e) => panic!(e),
         }
@@ -367,48 +396,28 @@ mod tests {
 
     #[test]
     fn test_text_add_line_in_contents() {
-        match text_add_line_in_contents(
-            &ContentGetterMock::new(Ok(Vec::new())),
-            1,
-            "Hello, World!".to_string(),
-        ) {
+        match text_add_line_in_str("", 1, "Hello, World!".to_string()) {
             Ok(s) => assert_eq!(s, "Hello, World!\n"),
             Err(e) => panic!(e),
         }
 
-        match text_add_line_in_contents(
-            &ContentGetterMock::new(Ok(vec!["first line".to_string()])),
-            1,
-            "Hello, World!".to_string(),
-        ) {
+        match text_add_line_in_str("first line", 1, "Hello, World!".to_string()) {
             Ok(s) => assert_eq!(s, "Hello, World!\nfirst line\n"),
             Err(e) => panic!(e),
         }
 
-        match text_add_line_in_contents(
-            &ContentGetterMock::new(Ok(vec!["first line".to_string()])),
-            2,
-            "Hello, World!".to_string(),
-        ) {
+        match text_add_line_in_str("first line", 2, "Hello, World!".to_string()) {
             Ok(s) => assert_eq!(s, "first line\nHello, World!\n"),
             Err(e) => panic!(e),
         }
 
-        match text_add_line_in_contents(
-            &ContentGetterMock::new(Ok(vec!["first line".to_string(), "last line".to_string()])),
-            2,
-            "Hello, World!".to_string(),
-        ) {
+        match text_add_line_in_str("first line\nlast line", 2, "Hello, World!".to_string()) {
             Ok(s) => assert_eq!(s, "first line\nHello, World!\nlast line\n"),
             Err(e) => panic!(e),
         }
 
-        match text_add_line_in_contents(
-            &ContentGetterMock::new(Ok(vec![
-                "# Header".to_string(),
-                "".to_string(),
-                "- [ ] Do the stuff".to_string(),
-            ])),
+        match text_add_line_in_str(
+            "# Header\n\n- [ ] Do the stuff",
             3,
             "Hello, World!".to_string(),
         ) {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,199 +1,281 @@
 #[cfg(test)]
+pub mod test {
+    use crate::model::Task;
+    use crate::services::UserCmdRunner;
+    use std::process::Command;
 
-pub fn env_getter_none(_: &str) -> Option<String> {
-    return None;
-}
-
-#[allow(dead_code)]
-pub fn home_getter_guybrush() -> Option<std::path::PathBuf> {
-    return Some(std::path::PathBuf::from("/home/guybrush"));
-}
-
-#[allow(dead_code)]
-pub fn env_getter_taxfile(name: &str) -> Option<String> {
-    match name {
-        "TAX_FILE" => Some("/path/to/overriden/taxfile".to_string()),
-        _ => None,
-    }
-}
-pub struct FileReaderMock {
-    pub outcome: Result<Vec<String>, String>,
-}
-impl crate::services::ContentGetter for FileReaderMock {
-    fn get_contents(&self) -> Result<Vec<String>, String> {
-        self.outcome.clone()
-    }
-}
-pub struct StringOutputerMock {
-    pub info_buf: Vec<String>,
-}
-impl StringOutputerMock {
-    #[allow(dead_code)]
-    pub fn new() -> Self {
-        return StringOutputerMock { info_buf: vec![] };
+    pub fn env_getter_none(_: &str) -> Option<String> {
+        return None;
     }
 
     #[allow(dead_code)]
-    pub fn get_info(&self) -> String {
-        self.info_buf.join("")
+    pub fn home_getter_guybrush() -> Option<std::path::PathBuf> {
+        return Some(std::path::PathBuf::from("/home/guybrush"));
     }
-}
-impl crate::services::StringOutputer for StringOutputerMock {
-    fn info(&mut self, s: String) -> () {
-        self.info_buf.push(String::from(format!("{}\n", s)));
+
+    #[allow(dead_code)]
+    pub fn env_getter_taxfile(name: &str) -> Option<String> {
+        match name {
+            "TAX_FILE" => Some("/path/to/overriden/taxfile".to_string()),
+            _ => None,
+        }
     }
-}
+    // ////////////////////////////////////////////////////////////////////////////
+    // ContentGetterMock
+    // ////////////////////////////////////////////////////////////////////////////
+    pub struct ContentGetterMock {
+        outcome: Result<Vec<String>, String>,
+    }
+    impl ContentGetterMock {
+        #[allow(dead_code)]
+        pub fn new(outcome: Result<Vec<String>, String>) -> Self {
+            return ContentGetterMock { outcome: outcome };
+        }
+    }
+    impl crate::services::ContentGetter for ContentGetterMock {
+        fn get_contents(&self) -> Result<Vec<String>, String> {
+            self.outcome.clone()
+        }
+    }
 
-#[allow(dead_code)]
-pub fn get_std_test_contents() -> (Vec<String>, Vec<crate::model::Task>) {
-    (
-        vec![
-            String::from("# Not a task"),
-            String::from("- [ ] Standard unchecked"),
-            String::from("- [ ] **Standard unchecked focused**"),
-            String::from("Also not a task"),
-            String::from("- [x] Checked"),
-            String::from("- [x] **Focused checked**"),
-            String::from("- [ ] Standard unchecked // with comments"),
-            String::from("- [ ] **Standard unchecked focused** // with comments"),
-        ],
-        vec![
-            crate::model::Task {
-                num: 1,
-                line_num: 2,
-                line: String::from("- [ ] Standard unchecked"),
-                name: String::from("Standard unchecked"),
-                plain_name: String::from("Standard unchecked"),
-                is_checked: false,
-                is_focused: false,
-                comment: None,
-            },
-            crate::model::Task {
-                num: 2,
-                line_num: 3,
-                line: String::from("- [ ] **Standard unchecked focused**"),
-                name: String::from("**Standard unchecked focused**"),
-                plain_name: String::from("Standard unchecked focused"),
-                is_checked: false,
-                is_focused: true,
-                comment: None,
-            },
-            crate::model::Task {
-                num: 3,
-                line_num: 5,
-                line: String::from("- [x] Checked"),
-                name: String::from("Checked"),
-                plain_name: String::from("Checked"),
-                is_checked: true,
-                is_focused: false,
-                comment: None,
-            },
-            crate::model::Task {
-                num: 4,
-                line_num: 6,
-                line: String::from("- [x] **Focused checked**"),
-                name: String::from("**Focused checked**"),
-                plain_name: String::from("Focused checked"),
-                is_checked: true,
-                is_focused: true,
-                comment: None,
-            },
-            crate::model::Task {
-                num: 5,
-                line_num: 7,
-                line: String::from("- [ ] Standard unchecked // with comments"),
-                name: String::from("Standard unchecked"),
-                plain_name: String::from("Standard unchecked"),
-                is_checked: false,
-                is_focused: false,
-                comment: Some(String::from("with comments")),
-            },
-            crate::model::Task {
-                num: 6,
-                line_num: 8,
-                line: String::from("- [ ] **Standard unchecked focused** // with comments"),
-                name: String::from("**Standard unchecked focused**"),
-                plain_name: String::from("Standard unchecked focused"),
-                is_checked: false,
-                is_focused: true,
-                comment: Some(String::from("with comments")),
-            },
-        ],
-    )
-}
+    // ////////////////////////////////////////////////////////////////////////////
+    // ContentSetterMock
+    // ////////////////////////////////////////////////////////////////////////////
+    pub struct ContentSetterMock {
+        pub content: Option<String>,
+        outcome: Result<(), String>,
+    }
+    impl ContentSetterMock {
+        pub fn new(outcome: Result<(), String>) -> Self {
+            return ContentSetterMock {
+                content: None,
+                outcome: outcome,
+            };
+        }
+    }
 
-#[allow(dead_code)]
-pub fn get_std_test_tasks() -> (Vec<String>, Vec<crate::model::Task>) {
-    (
-        vec![
-            String::from("- [ ] Standard unchecked"),
-            String::from("- [ ] **Standard unchecked focused**"),
-            String::from("- [x] Checked"),
-            String::from("- [x] **Focused checked**"),
-            String::from("- [ ] Standard unchecked // with comments"),
-            String::from("- [ ] **Standard unchecked focused** // with comments"),
-        ],
-        vec![
-            crate::model::Task {
-                num: 1,
-                line_num: 1,
-                line: String::from("- [ ] Standard unchecked"),
-                name: String::from("Standard unchecked"),
-                plain_name: String::from("Standard unchecked"),
-                is_checked: false,
-                is_focused: false,
-                comment: None,
-            },
-            crate::model::Task {
-                num: 2,
-                line_num: 2,
-                line: String::from("- [ ] **Standard unchecked focused**"),
-                name: String::from("**Standard unchecked focused**"),
-                plain_name: String::from("Standard unchecked focused"),
-                is_checked: false,
-                is_focused: true,
-                comment: None,
-            },
-            crate::model::Task {
-                num: 3,
-                line_num: 3,
-                line: String::from("- [x] Checked"),
-                name: String::from("Checked"),
-                plain_name: String::from("Checked"),
-                is_checked: true,
-                is_focused: false,
-                comment: None,
-            },
-            crate::model::Task {
-                num: 4,
-                line_num: 4,
-                line: String::from("- [x] **Focused checked**"),
-                name: String::from("**Focused checked**"),
-                plain_name: String::from("Focused checked"),
-                is_checked: true,
-                is_focused: true,
-                comment: None,
-            },
-            crate::model::Task {
-                num: 5,
-                line_num: 5,
-                line: String::from("- [ ] Standard unchecked // with comments"),
-                name: String::from("Standard unchecked"),
-                plain_name: String::from("Standard unchecked"),
-                is_checked: false,
-                is_focused: false,
-                comment: Some(String::from("with comments")),
-            },
-            crate::model::Task {
-                num: 6,
-                line_num: 6,
-                line: String::from("- [ ] **Standard unchecked focused** // with comments"),
-                name: String::from("**Standard unchecked focused**"),
-                plain_name: String::from("Standard unchecked focused"),
-                is_checked: false,
-                is_focused: true,
-                comment: Some(String::from("with comments")),
-            },
-        ],
-    )
+    impl crate::services::ContentSetter for ContentSetterMock {
+        fn set_contents(&mut self, contents: String) -> Result<(), String> {
+            self.content = Some(contents);
+            return self.outcome.clone();
+        }
+    }
+
+    // ////////////////////////////////////////////////////////////////////////////
+    // StringOutputerMock
+    // ////////////////////////////////////////////////////////////////////////////
+    pub struct StringOutputerMock {
+        info_buf: Vec<String>,
+    }
+    impl StringOutputerMock {
+        #[allow(dead_code)]
+        pub fn new() -> Self {
+            return StringOutputerMock { info_buf: vec![] };
+        }
+        #[allow(dead_code)]
+        pub fn get_info(&self) -> String {
+            self.info_buf.join("")
+        }
+    }
+    impl crate::services::StringOutputer for StringOutputerMock {
+        fn info(&mut self, s: String) -> () {
+            self.info_buf.push(String::from(format!("{}\n", s)));
+        }
+    }
+
+    // ////////////////////////////////////////////////////////////////////////////
+    // UserCmdRunnerMock
+    // ////////////////////////////////////////////////////////////////////////////
+    pub struct UserCmdRunnerMock {}
+
+    impl UserCmdRunnerMock {
+        pub fn new() -> Self {
+            UserCmdRunnerMock {}
+        }
+    }
+
+    impl UserCmdRunner for UserCmdRunnerMock {
+        fn env_single_task<'a>(&self, _: Task, cmd: &'a mut Command) -> &'a mut Command {
+            cmd
+        }
+
+        fn build(&self, _: String, _: String, _: String) -> Result<Option<Command>, String> {
+            Ok(None)
+        }
+
+        fn run(&self, _: &mut Command) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    // ////////////////////////////////////////////////////////////////////////
+    // TaskFormatterMock
+    // ////////////////////////////////////////////////////////////////////////
+    #[allow(dead_code)]
+    pub struct TaskFormatterMock {}
+
+    #[allow(dead_code)]
+    pub fn get_std_test_contents() -> (Vec<String>, Vec<crate::model::Task>) {
+        (
+            vec![
+                String::from("Not a task"),
+                String::from("- [ ] Standard unchecked"),
+                String::from("- [ ] **Standard unchecked focused**"),
+                String::from("Also not a task"),
+                String::from("- [x] Checked"),
+                String::from("- [x] **Focused checked**"),
+                String::from("- [ ] Standard unchecked // with comments"),
+                String::from("- [ ] **Standard unchecked focused** // with comments"),
+            ],
+            vec![
+                crate::model::Task {
+                    num: 1,
+                    line_num: 2,
+                    line: String::from("- [ ] Standard unchecked"),
+                    name: String::from("Standard unchecked"),
+                    plain_name: String::from("Standard unchecked"),
+                    is_checked: false,
+                    is_focused: false,
+                    comment: None,
+                    section: None,
+                },
+                crate::model::Task {
+                    num: 2,
+                    line_num: 3,
+                    line: String::from("- [ ] **Standard unchecked focused**"),
+                    name: String::from("**Standard unchecked focused**"),
+                    plain_name: String::from("Standard unchecked focused"),
+                    is_checked: false,
+                    is_focused: true,
+                    comment: None,
+                    section: None,
+                },
+                crate::model::Task {
+                    num: 3,
+                    line_num: 5,
+                    line: String::from("- [x] Checked"),
+                    name: String::from("Checked"),
+                    plain_name: String::from("Checked"),
+                    is_checked: true,
+                    is_focused: false,
+                    comment: None,
+                    section: None,
+                },
+                crate::model::Task {
+                    num: 4,
+                    line_num: 6,
+                    line: String::from("- [x] **Focused checked**"),
+                    name: String::from("**Focused checked**"),
+                    plain_name: String::from("Focused checked"),
+                    is_checked: true,
+                    is_focused: true,
+                    comment: None,
+                    section: None,
+                },
+                crate::model::Task {
+                    num: 5,
+                    line_num: 7,
+                    line: String::from("- [ ] Standard unchecked // with comments"),
+                    name: String::from("Standard unchecked"),
+                    plain_name: String::from("Standard unchecked"),
+                    is_checked: false,
+                    is_focused: false,
+                    comment: Some(String::from("with comments")),
+                    section: None,
+                },
+                crate::model::Task {
+                    num: 6,
+                    line_num: 8,
+                    line: String::from("- [ ] **Standard unchecked focused** // with comments"),
+                    name: String::from("**Standard unchecked focused**"),
+                    plain_name: String::from("Standard unchecked focused"),
+                    is_checked: false,
+                    is_focused: true,
+                    comment: Some(String::from("with comments")),
+                    section: None,
+                },
+            ],
+        )
+    }
+    #[allow(dead_code)]
+    pub fn get_std_test_tasks() -> (Vec<String>, Vec<crate::model::Task>) {
+        (
+            vec![
+                String::from("- [ ] Standard unchecked"),
+                String::from("- [ ] **Standard unchecked focused**"),
+                String::from("- [x] Checked"),
+                String::from("- [x] **Focused checked**"),
+                String::from("- [ ] Standard unchecked // with comments"),
+                String::from("- [ ] **Standard unchecked focused** // with comments"),
+            ],
+            vec![
+                crate::model::Task {
+                    num: 1,
+                    line_num: 1,
+                    line: String::from("- [ ] Standard unchecked"),
+                    name: String::from("Standard unchecked"),
+                    plain_name: String::from("Standard unchecked"),
+                    is_checked: false,
+                    is_focused: false,
+                    comment: None,
+                    section: None,
+                },
+                crate::model::Task {
+                    num: 2,
+                    line_num: 2,
+                    line: String::from("- [ ] **Standard unchecked focused**"),
+                    name: String::from("**Standard unchecked focused**"),
+                    plain_name: String::from("Standard unchecked focused"),
+                    is_checked: false,
+                    is_focused: true,
+                    comment: None,
+                    section: None,
+                },
+                crate::model::Task {
+                    num: 3,
+                    line_num: 3,
+                    line: String::from("- [x] Checked"),
+                    name: String::from("Checked"),
+                    plain_name: String::from("Checked"),
+                    is_checked: true,
+                    is_focused: false,
+                    comment: None,
+                    section: None,
+                },
+                crate::model::Task {
+                    num: 4,
+                    line_num: 4,
+                    line: String::from("- [x] **Focused checked**"),
+                    name: String::from("**Focused checked**"),
+                    plain_name: String::from("Focused checked"),
+                    is_checked: true,
+                    is_focused: true,
+                    comment: None,
+                    section: None,
+                },
+                crate::model::Task {
+                    num: 5,
+                    line_num: 5,
+                    line: String::from("- [ ] Standard unchecked // with comments"),
+                    name: String::from("Standard unchecked"),
+                    plain_name: String::from("Standard unchecked"),
+                    is_checked: false,
+                    is_focused: false,
+                    comment: Some(String::from("with comments")),
+                    section: None,
+                },
+                crate::model::Task {
+                    num: 6,
+                    line_num: 6,
+                    line: String::from("- [ ] **Standard unchecked focused** // with comments"),
+                    name: String::from("**Standard unchecked focused**"),
+                    plain_name: String::from("Standard unchecked focused"),
+                    is_checked: false,
+                    is_focused: true,
+                    comment: Some(String::from("with comments")),
+                    section: None,
+                },
+            ],
+        )
+    }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -80,7 +80,7 @@ pub mod test {
         }
     }
     impl crate::services::StringOutputer for StringOutputerMock {
-        fn info(&mut self, s: String) -> () {
+        fn info(&mut self, s: &str) -> () {
             self.info_buf.push(String::from(format!("{}\n", s)));
         }
     }
@@ -97,11 +97,11 @@ pub mod test {
     }
 
     impl UserCmdRunner for UserCmdRunnerMock {
-        fn env_single_task<'a>(&self, _: Task, cmd: &'a mut Command) -> &'a mut Command {
+        fn env_single_task<'a>(&self, _: &Task, cmd: &'a mut Command) -> &'a mut Command {
             cmd
         }
 
-        fn build(&self, _: String, _: String, _: String) -> Result<Option<Command>, String> {
+        fn build(&self, _: &str, _: &str, _: &str) -> Result<Option<Command>, String> {
             Ok(None)
         }
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -24,16 +24,18 @@ pub mod test {
     // ContentGetterMock
     // ////////////////////////////////////////////////////////////////////////////
     pub struct ContentGetterMock {
-        outcome: Result<Vec<String>, String>,
+        outcome: Result<String, String>,
     }
+
     impl ContentGetterMock {
         #[allow(dead_code)]
-        pub fn new(outcome: Result<Vec<String>, String>) -> Self {
+        pub fn new(outcome: Result<String, String>) -> Self {
             return ContentGetterMock { outcome: outcome };
         }
     }
+
     impl crate::services::ContentGetter for ContentGetterMock {
-        fn get_contents(&self) -> Result<Vec<String>, String> {
+        fn get_contents(&self) -> Result<String, String> {
             self.outcome.clone()
         }
     }
@@ -115,7 +117,7 @@ pub mod test {
     pub struct TaskFormatterMock {}
 
     #[allow(dead_code)]
-    pub fn get_std_test_contents() -> (Vec<String>, Vec<crate::model::Task>) {
+    pub fn get_std_test_contents() -> (String, Vec<crate::model::Task>) {
         (
             vec![
                 String::from("Not a task"),
@@ -126,7 +128,8 @@ pub mod test {
                 String::from("- [x] **Focused checked**"),
                 String::from("- [ ] Standard unchecked // with comments"),
                 String::from("- [ ] **Standard unchecked focused** // with comments"),
-            ],
+            ]
+            .join("\n"),
             vec![
                 crate::model::Task {
                     num: 1,
@@ -198,7 +201,7 @@ pub mod test {
         )
     }
     #[allow(dead_code)]
-    pub fn get_std_test_tasks() -> (Vec<String>, Vec<crate::model::Task>) {
+    pub fn get_std_test_tasks() -> (String, Vec<crate::model::Task>) {
         (
             vec![
                 String::from("- [ ] Standard unchecked"),
@@ -207,7 +210,8 @@ pub mod test {
                 String::from("- [x] **Focused checked**"),
                 String::from("- [ ] Standard unchecked // with comments"),
                 String::from("- [ ] **Standard unchecked focused** // with comments"),
-            ],
+            ]
+            .join("\n"),
             vec![
                 crate::model::Task {
                     num: 1,


### PR DESCRIPTION
Markdown headers are recognized as sections, and handled by tax:

One section at a time can be focused; tax will only display the tasks from the focused section, and all tasks otherwise.

Tasks are added to the focused section if any. Tasks can be added to any section using the optional `--section` (`-s`) parameter.